### PR TITLE
Handle null string

### DIFF
--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -5,7 +5,11 @@ export function insertMentionLinks(markdown: string) {
   )
 }
 
-export function shorten(text = '', maxLength = 140) {
+export function shorten(text: string | null = '', maxLength = 140) {
+  if (text === null) {
+    return ''
+  }
+
   // Normalize newlines
   let cleanText = text.replace(/\\r\\n/g, '\n')
 


### PR DESCRIPTION
The default behavior upon starting the app with current implementation is failure due to null value where string is expected. 

<img width="608" alt="Screen Shot 2022-04-25 at 5 49 39 AM" src="https://user-images.githubusercontent.com/1081979/165065341-8907aade-b228-4430-9873-7df58569e253.png">

This PR fixes that by returning an empty string in `shorten()` given a null argument.